### PR TITLE
Improved Debian/Ubuntu install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ gem install audite
 
 ## Debian / Ubuntu Install
 ```
+apt-get install libjack0 libjack-dev
 apt-get install libportaudiocpp0 portaudio19-dev libmpg123-dev
 gem install audite
 ```


### PR DESCRIPTION
On Ubuntu 12.04, got dependencies error that required me to install libjack0 and libjack-dev, so I included those dependencies.
