### PR TITLE
Update to work on Ruby 2.2.0

### DIFF
--- a/ext/portaudio/portaudio.c
+++ b/ext/portaudio/portaudio.c
@@ -136,7 +136,7 @@ VALUE rb_portaudio_wait(VALUE self)
   Data_Get_Struct(self, Portaudio, portaudio);
 
 #ifdef RUBY_UBF_IO
-  rb_thread_blocking_region(portaudio_wait, portaudio, RUBY_UBF_IO, NULL);
+  rb_thread_call_without_gvl(portaudio_wait, portaudio, RUBY_UBF_IO, NULL);
 #else
   portaudio_wait(portaudio);
 #endif


### PR DESCRIPTION
`rb_thread_blocking_region` no longer exists in Ruby 2.2.0. Instead, use `rb_thread_call_without_gvl`, which has been in Ruby for a while.

Confirmed to work on these MRI Ruby versions:

* 2.2.0
* 2.1.5
* 1.9.3