### PR TITLE
Fix a memory leak in portaudio.c

### DIFF
--- a/ext/portaudio/extconf.rb
+++ b/ext/portaudio/extconf.rb
@@ -7,10 +7,24 @@ unless have_header('portaudio.h')
   exit
 end
 
+unless have_header('mpg123.h')
+  puts "mpg123.h not found"
+  puts "please brew install mpg123"
+  puts "or apt-get install libmpg123-dev"
+  exit
+end
+
 unless have_library('portaudio')
   puts "lib portaudio not found"
   puts "brew install portaudio"
   puts "or apt-get install portaudio19-dev"
+  exit
+end
+
+unless have_library('mpg123')
+  puts "lib mpg123 not found"
+  puts "please brew install mpg123"
+  puts "or apt-get install libmpg123-0"
   exit
 end
 

--- a/ext/portaudio/portaudio.c
+++ b/ext/portaudio/portaudio.c
@@ -59,7 +59,6 @@ VALUE rb_portaudio_new(VALUE klass, VALUE framesPerBuffer, VALUE deviceName)
   const PaDeviceInfo *deviceInfo;
   PaError err;
   int device, numDevices, foundDevice = -1;
-  char* dName = malloc(sizeof(char) * strlen(StringValuePtr(deviceName)));
   VALUE self;
   Portaudio *portaudio = (Portaudio *) malloc(sizeof(Portaudio));
 
@@ -68,7 +67,6 @@ VALUE rb_portaudio_new(VALUE klass, VALUE framesPerBuffer, VALUE deviceName)
 
   portaudio->size = FIX2INT(framesPerBuffer) * 2;
   portaudio->buffer = (float *) malloc(sizeof(float) * portaudio->size);
-	strcpy(dName, StringValuePtr(deviceName));
 	numDevices = Pa_GetDeviceCount();
 	if( numDevices < 0 ) {
 		printf( "ERROR: Pa_CountDevices returned 0x%x\n", numDevices );
@@ -77,7 +75,7 @@ VALUE rb_portaudio_new(VALUE klass, VALUE framesPerBuffer, VALUE deviceName)
 
 	for ( device=0; device<numDevices; device++ ) {
 		deviceInfo = Pa_GetDeviceInfo( device );
-		if (strcmp(deviceInfo->name, dName) == 0) {
+		if (strcmp(deviceInfo->name, StringValueCStr(deviceName)) == 0) {
 			foundDevice = device;
 			break;
 		}


### PR DESCRIPTION
Eliminate the malloc call altogether
